### PR TITLE
Add support for Podman pod feature and for RHEL/CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ podman_services:
     # If the network does not exist it will be created. This can be used to allow
     # multiple services to network with each other. See Networking for caveats
     network: somenetwork
+    # Optional: String name of the pod to be passed to --pod flag.
+    # If the pod does not exist it will be created.
+    pod: somepod
     # Optional: List of volumes to mount. Takes the same form as the
     # podman CLI host-directory:container-directory and as shown below
     # mount options are allowed.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ podman_services:
     network: somenetwork
     # Optional: String name of the pod to be passed to --pod flag.
     # If the pod does not exist it will be created.
-    pod: somepod
+    # If you specify a port map (optional) it will be passed to --publish.
+    pod:
+      name: somepod
+      ports: [80: 80, 443: 443]
     # Optional: List of volumes to mount. Takes the same form as the
     # podman CLI host-directory:container-directory and as shown below
     # mount options are allowed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,4 +8,3 @@ podman_tools:
     - buildah
     - skopeo
 podman_services: []
-podman_pods: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ podman_tools:
     - buildah
     - skopeo
 podman_services: []
+podman_pods: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,6 +26,9 @@
   include_tasks: ubuntu.yml
   when: ansible_distribution == "Ubuntu"
 
+- name: Include tasks to create pods
+  include_tasks: podman_pods.yml
+
 - include_tasks: podman_service.yml
   loop: "{{ podman_services }}"
   loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,13 +9,15 @@
     state: directory
     path: /etc/containers
 
-# Podman uses this, on at least Ubuntu, to do port publishing.
-- name: Ensure iptables is installed
+# Podman uses iptables, on at least Ubuntu, to do port publishing.
+- name: Ensure required packages are installed
   become: true
   become_user: root
   package:
-    name: iptables
-    state: present
+    name: "{{item}}"
+  loop:
+    - iptables
+    - jq
 
 - name: Include tasks for Red Hat OS family
   include_tasks: redhat.yml

--- a/tasks/podman_pods.yml
+++ b/tasks/podman_pods.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Determine list of required pods
+  set_fact:
+    podman_pods: "{{ podman_pods }} + [ '{{ service.pod }}' ]"
+  when: service.pod is defined
+  loop: "{{ podman_services }}"
+  loop_control:
+    loop_var: service
+
+- name: Get list of pods
+  shell: podman pod ps --format {% raw %}'{{.Name}}'{% endraw %}
+  register: podman_pod_ps
+  when: podman_pods | length > 0
+
+- name: Create required pods
+  loop: "{{podman_pods}}"
+  loop_control:
+    loop_var: pod
+  when: pod not in podman_pod_ps.stdout_lines
+  shell: podman pod create --name "{{pod}}"

--- a/tasks/podman_pods.yml
+++ b/tasks/podman_pods.yml
@@ -1,21 +1,32 @@
 ---
 
-- name: Determine list of required pods
-  set_fact:
-    podman_pods: "{{ podman_pods }} + [ '{{ service.pod }}' ]"
+- name: Determine list of required pods and ports
   when: service.pod is defined
   loop: "{{ podman_services }}"
   loop_control:
     loop_var: service
+  set_fact:
+    podman_pods: "{{ podman_pods | default({}) | combine({service.pod.name: {'name': service.pod.name, 'ports': service.pod.ports | default([]) + (podman_pods[service.pod.name]['ports'] | default([]))}}) }}"
 
-- name: Get list of pods
-  shell: podman pod ps --format {% raw %}'{{.Name}}'{% endraw %}
-  register: podman_pod_ps
-  when: podman_pods | length > 0
-
-- name: Create required pods
-  loop: "{{podman_pods}}"
+- name: Delete pods with missing port bindings
+  loop: "{{ podman_pods | subelements('ports', skip_missing=yes) }}"
   loop_control:
     loop_var: pod
-  when: pod not in podman_pod_ps.stdout_lines
-  shell: podman pod create --name "{{pod}}"
+  when: pod.0.ports is defined
+  shell: |
+    podman pod exists {{pod.0.name}} \
+    && (podman pod inspect {{pod.0.name}} \
+    | jq -e ".Config.infraConfig.infraPortBindings[] | select(.hostPort=={{ lookup('dict', pod.1).key }} and .containerPort=={{ lookup('dict', pod.1).value }})" \
+    || podman pod rm -f {{pod.0.name}}) || true
+  register: podman_pod_inspect
+
+- name: Create required pods
+  loop: "{{podman_pods | dict2items }}"
+  loop_control:
+    loop_var: pod
+  shell: |
+    podman pod exists "{{pod.key}}" \
+    ||  podman pod create --name "{{pod.key}}" \
+    {% if pod.value.ports|default([])|length > 0 %}\
+      --publish {% for port in pod.value.ports %}{{lookup('dict', port).key}}:{{lookup('dict', port).value}}{%- if not loop.last -%},{%- endif -%}{% endfor %}\
+    {% endif %}

--- a/templates/podman.service
+++ b/templates/podman.service
@@ -23,8 +23,8 @@ ExecStart=/usr/bin/podman run \
                           {% if service.network is defined %}
                           --network {{ service.network }}
                           {% endif %}
-                          {% if service.pod is defined %}
-                          --pod {{ service.pod }} \
+                          {% if service.pod.name is defined %}
+                          --pod {{ service.pod.name }} \
                           {% endif %}
                           {% if service.publish is defined %}
                           {% for publish in service.publish %}

--- a/templates/podman.service
+++ b/templates/podman.service
@@ -23,6 +23,9 @@ ExecStart=/usr/bin/podman run \
                           {% if service.network is defined %}
                           --network {{ service.network }}
                           {% endif %}
+                          {% if service.pod is defined %}
+                          --pod {{ service.pod }} \
+                          {% endif %}
                           {% if service.publish is defined %}
                           {% for publish in service.publish %}
                           --publish {{ publish }} \


### PR DESCRIPTION
The role currently uses `dnf` to install Podman tools. The packages are first available on Fedora 28 and `dnf` was introduced to RHEL/CentOS with major version 8. Therefore we check against Fedora 28 and RHEL/CentOS 8 when including the dnf tasks. 

This PR also adds the ability to use the Podman Pod feature. The role user will want to put the containers created by this role (or rather systemd) into Podman Pods. These have to be created beforehand. I implemented task logic to first check for existing pods with the same name. If a pod matches and doesn't have the published ports as requested by the role variables the pod will be deleted.

The tasks will always try to create the pod with the specified ports, if it doesn't exist.

The containers will then be assigned to a pod using the `--pod` argument in the systemd unit.

I had to use a different format for the published port mapping (dict vs. string) to properly detected existing pods with "outdated" port mappings.

I tested the role against CentOS 8 with different pod configurations (no pod assigned, pod assigned with no published ports, pod assigned with multiple ports).

What do you think about this contribution?