### PR TITLE
Add support for Enterprise Linux

### DIFF
--- a/tasks/fedora.yml
+++ b/tasks/fedora.yml
@@ -1,7 +1,0 @@
----
-
-- name: RedHat | Install Podman suite of tools
-  become: true
-  become_user: root
-  dnf:
-    name: "{{ podman_tools }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,14 +15,19 @@
   become_user: root
   package:
     name: iptables
+    state: present
 
-- include_tasks: fedora.yml
-  when: ansible_distribution == "Fedora"
+- name: Include tasks for Red Hat OS family
+  include_tasks: redhat.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('28', '>=')) or
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('7', '>='))
 
-- include_tasks: ubuntu.yml
+- name: Include tasks for Ubuntu
+  include_tasks: ubuntu.yml
   when: ansible_distribution == "Ubuntu"
 
 - include_tasks: podman_service.yml
   loop: "{{ podman_services }}"
   loop_control:
     loop_var: service
+

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,17 @@
+---
+
+- name: RedHat DNF | Install Podman suite of tools
+  become: true
+  become_user: root
+  dnf:
+    name: "{{ podman_tools }}"
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('28', '>=')) or
+    (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+
+- name: RedHat YUM | Install Podman suite of tools
+  become: true
+  become_user: root
+  yum:
+    name: "{{ podman_tools }}"
+  when: (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('7', '=='))
+


### PR DESCRIPTION
This is contribution is split from #1.

> The role currently uses dnf to install Podman tools. The packages are first available on Fedora 28 and dnf was introduced to RHEL/CentOS with major version 8. Therefore we check against Fedora 28 and RHEL/CentOS 8 when including the dnf tasks.

RHEL/CentOS 7 is supported by falling back to `yum`.

I tested this against CentOS 7 and CentOS 8.