### PR TITLE
Run restart service handler as root

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: "restart podman service"
+  become: true
+  become_user: root
   systemd:
     name: "{{ __podman_service_name }}"
     state: restarted


### PR DESCRIPTION
Without this the handler that should restart the service always errors
out when something about a podman service changes:

    RUNNING HANDLER [podman : restart podman service]
    fatal: [server]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload: Failed to reload daemon: Method call timed out\n"}