### PR TITLE
Fix ppa podman (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Manage services and containers with podman
 Usage
 -----
 
-By default this role will simply install podman and perform any other required
+By default this role will simply install podman as described in the [podman docs](https://podman.io/getting-started/installation.html) and perform any other required
 setup to make the installation functional on the supported platforms. 
 
 Additionally, it can deploy and configure podman containers as SystemD services.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Usage
 By default this role will simply install podman as described in the [podman docs](https://podman.io/getting-started/installation.html) and perform any other required
 setup to make the installation functional on the supported platforms. 
 
+**Important Note:** This means that for Ubuntu / Debian systems it will perform an `apt upgrade` as per the docs after the repository is added. This upgrade will only be run if the repository is added or changed and will not execute on subsequent runs.
+
 Additionally, it can deploy and configure podman containers as SystemD services.
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
-podman_apt_repo: ppa:projectatomic/ppa
+podman_apt_repo: "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ ansible_distribution_version }} /"
+podman_apt_pub_key: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_{{ ansible_distribution_version }}/Release.key"
+
 # Users may not want to install all the podman tools everywhere so this variable
 # allows you to scope down what tools to install. For instance I do not install
 # buildah or skopeo on my servers because I do not build images on them.

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -11,10 +11,12 @@
   apt_repository:
     repo: "{{ podman_apt_repo }}"
     filename: podman
+  register: podman_apt_repo
 
 - name: Ubuntu | Upgrade System before install
   apt:
     upgrade: dist
+  when: podman_apt_repo.changed
 
 # Conmon requires libglib2.0 to be installed however, the ppa packages do not
 # include it as a dependency. This is an upstream packaging bug and this breaks

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -1,10 +1,16 @@
 ---
 
+- name: Ubuntu | Add an Apt signing key used for podman repo
+  apt_key:
+    url: "{{ podman_apt_pub_key }}"
+    state: present
+
 - name: Ubuntu | Add podman repository
   become: true
   become_user: root
   apt_repository:
     repo: "{{ podman_apt_repo }}"
+    filename: podman
 
 # Conmon requires libglib2.0 to be installed however, the ppa packages do not
 # include it as a dependency. This is an upstream packaging bug and this breaks

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -12,6 +12,10 @@
     repo: "{{ podman_apt_repo }}"
     filename: podman
 
+- name: Ubuntu | Upgrade System before install
+  apt:
+    upgrade: dist
+
 # Conmon requires libglib2.0 to be installed however, the ppa packages do not
 # include it as a dependency. This is an upstream packaging bug and this breaks
 # podman as it cannot load the runtime because it cannot run conmon.


### PR DESCRIPTION
The current used ppa is not recommended by the official podman install guide and not working with Ubuntu 20.04  