### PR TITLE
Why does the role use `dist-upgrade` to install Podman?

### DIFF
--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -15,7 +15,7 @@
 
 - name: Ubuntu | Upgrade System before install
   apt:
-    upgrade: dist
+    upgrade: yes
   when: podman_apt_repo.changed
 
 # Conmon requires libglib2.0 to be installed however, the ppa packages do not


### PR DESCRIPTION
The role currently uses `dist-upgrade` to install Podman for Ubuntu.
But [official instructions](https://podman.io/getting-started/installation#ubuntu) use `upgrade`, not `dist-upgrade`.

I've created a PR that follows official instructions.
It seems to work fine both ways to me.
If there is no reason to use `dist-upgrade`, it is better to follow official instructions.

What do you think about this contribution?

### In the role

[https://github.com/chasinglogic/ansible-role-podman/blob/24d44cd63ba0b0ebe05cb4da1b3e24808a434358/tasks/ubuntu.yml#L16-L19](https://github.com/chasinglogic/ansible-role-podman/blob/24d44cd63ba0b0ebe05cb4da1b3e24808a434358/tasks/ubuntu.yml#L16-L19)

### In official instructions

```
. /etc/os-release
echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key" | sudo apt-key add -
sudo apt-get update
sudo apt-get -y upgrade
sudo apt-get -y install podman
```